### PR TITLE
ME-47 Исправление запроса на получение хостов сгруппированных по сценам

### DIFF
--- a/src/main/java/com/metaverse/files/converters/host/HostConverter.java
+++ b/src/main/java/com/metaverse/files/converters/host/HostConverter.java
@@ -29,7 +29,8 @@ public class HostConverter extends Converter<HostModel, HostRO> {
         ro.setSceneName(host.getScene().getName());
         ro.setUri(host.getUri());
         if (!CollectionUtils.isEmpty(host.getUser())) {
-            ro.setLogin(host.getUser().get(0).getName());
+            ro.setLogin(host.getUser().get(0).getLogin());
+            ro.setName(host.getUser().get(0).getName());
         }
 
         return ro;

--- a/src/main/java/com/metaverse/files/rest/HostsRest.java
+++ b/src/main/java/com/metaverse/files/rest/HostsRest.java
@@ -15,6 +15,7 @@ import com.metaverse.files.utils.exceptions.DataNotFoundException;
 import com.metaverse.files.utils.exceptions.ExceptionCode;
 import com.metaverse.files.utils.exceptions.UselessOperationException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -64,7 +65,7 @@ public class HostsRest {
     @GetMapping
     @Operation(summary = "Получить хостов указанной сцены", description = "Позволяет получить список всех хостов сцены указанной в пути запроса")
     @ApiResponse(responseCode = "200", description = "Список хостов указанной комнаты", content = @Content(schema = @Schema(implementation = SinglesceneHostsResultRO.class)))
-    public ResponseEntity<SinglesceneHostsResultRO> getHostsByScene(@RequestParam("sceneName") String sceneName) {
+    public ResponseEntity<SinglesceneHostsResultRO> getHostsByScene(@RequestParam("sceneName") @Parameter(description = "Имя сцены", required = true) String sceneName) {
         List<HostRO> hosts = hostsService.hostsByScene(sceneName);
 
         SinglesceneHostsResultRO resultRO = new SinglesceneHostsResultRO();

--- a/src/main/java/com/metaverse/files/ro/host/HostRO.java
+++ b/src/main/java/com/metaverse/files/ro/host/HostRO.java
@@ -13,10 +13,12 @@ public class HostRO {
 
     @Schema(description = "Uri идентификатор хоста, для подключения к нему через Mirror")
     private String uri;
-    @Schema(description = "Название файла сцены, хостом которой является создаваемый хост")
+    @Schema(description = "Название файла сцены, хостом которой является данный хост")
     private String sceneName;
     @Schema(description = "Логин пользователя являющегося хостом")
     private String login;
+    @Schema(description = "Отображаемое имя пользователя являющегося хостом")
+    private String name;
 
     /**
      * @return uri идентификатор хоста
@@ -58,5 +60,19 @@ public class HostRO {
      */
     public void setLogin(String login) {
         this.login = login;
+    }
+
+    /**
+     * @return отображаемое имя пользователя являющегося хостом
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name отображаемое имя пользователя являющегося хостом
+     */
+    public void setName(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/com/metaverse/files/services/host/HostServiceImp.java
+++ b/src/main/java/com/metaverse/files/services/host/HostServiceImp.java
@@ -46,14 +46,18 @@ public class HostServiceImp implements HostsService {
      */
     @Override
     public Map<String, List<HostRO>> hostsGroupedByScene() {
-        List<HostModel> hosts = hostsRepository.findAll();
-        return hosts.stream()
+        List<SceneModel> scenes = sceneRepository.findAll();
+
+        return scenes.stream()
                 .collect(
                         Collectors.groupingBy(
-                                e -> e.getScene().getName(),
-                                Collectors.mapping(
-                                        host -> hostConverter.to(host),
-                                        Collectors.toList()
+                                s -> s.getName(),
+                                Collectors.flatMapping(
+                                        s -> s.getHosts().stream(),
+                                        Collectors.mapping(
+                                                host -> hostConverter.to(host),
+                                                Collectors.toList()
+                                        )
                                 )
                         )
                 );


### PR DESCRIPTION
Problem:

- Хосты получаются из таблицы хостов. Из-за этого, если у сцены нет хостов - она не вернется в запросе
- У `HostRO` отсутствовало отображаемое имя пользователя, что усложняет работу клиента

Fix:

- Получить список сцен из таблицы сцен. Сгруппировать сцены по имени. Затем преобразовать результат группировки в список хостов сцены
- Добавить в `HostRO` отображаемое имя пользователя