### PR TITLE
ME-80 Инициализация хранилища дат обновления файлов сцен

### DIFF
--- a/src/main/java/com/metaverse/files/services/scene/SceneServiceImpl.java
+++ b/src/main/java/com/metaverse/files/services/scene/SceneServiceImpl.java
@@ -55,11 +55,15 @@ public class SceneServiceImpl implements SceneService {
      */
     private final ConcurrentHashMap<String, Date> sceneUpdates = new ConcurrentHashMap<>();
 
+    private boolean isSceneUpdatesInitialized = false;
+
     /**
      * {@inheritDoc}
      */
     @Override
     public List<SceneUpdateInfoRO> getUpdateInfos() {
+        ensureSceneUpdatesInitialized();
+
         List<SceneUpdateInfoRO> updateInfos = new ArrayList<>();
         for (var sceneUpdate : sceneUpdates.entrySet()) {
             SceneUpdateInfoRO updateInfo = new SceneUpdateInfoRO();
@@ -157,6 +161,7 @@ public class SceneServiceImpl implements SceneService {
         sceneModel.setImageFilePath(imageFullName.toString());
         sceneModel.setSortIndex(ctx.getSortIndex());
         sceneModel.setUpdateDate(TimeUtils.dateNow());
+        ensureSceneUpdatesInitialized();
         sceneUpdates.put(sceneModel.getName(), sceneModel.getUpdateDate());
 
         sceneRepository.save(sceneModel);
@@ -173,7 +178,9 @@ public class SceneServiceImpl implements SceneService {
 
         deleteFilesFromDisk(sceneFromDB);
 
+        ensureSceneUpdatesInitialized();
         sceneUpdates.remove(sceneFromDB.getName());
+
         sceneRepository.delete(sceneFromDB);
     }
 
@@ -198,6 +205,7 @@ public class SceneServiceImpl implements SceneService {
     @Transactional
     @Override
     public void delete(List<String> sceneNames) {
+        ensureSceneUpdatesInitialized();
         List<SceneModel> scenesFromDB = sceneRepository.findAllByNameIn(sceneNames);
         for (SceneModel sceneFromDB : scenesFromDB) {
             deleteFilesFromDisk(sceneFromDB);
@@ -205,5 +213,20 @@ public class SceneServiceImpl implements SceneService {
         }
 
         sceneRepository.deleteAll(scenesFromDB);
+    }
+
+    private void ensureSceneUpdatesInitialized() {
+        if (isSceneUpdatesInitialized) {
+            return;
+        }
+
+        LOGGER.info("Initializing scene updates...");
+
+        List<SceneInfoRO> allInfo = getAllInfo();
+        for (SceneInfoRO scene : allInfo) {
+            sceneUpdates.put(scene.getName(), scene.getUpdateDate());
+        }
+
+        isSceneUpdatesInitialized = true;
     }
 }


### PR DESCRIPTION
Problem:

- `SceneServiceImpl#sceneUpdates` заполняется только при добавлении и удалении сцены. Однако при запуске сервера, данное хранилище пусто, а сцены лежат в БД

Fix:

- Проверять инициализировано ли хранилище `SceneServiceImpl#sceneUpdates` в операциях, которые его используют. Если хранилище не инициализировано - заполнить его из БД